### PR TITLE
Initial Cache Impl

### DIFF
--- a/.applier/inventory/group_vars/all.yml
+++ b/.applier/inventory/group_vars/all.yml
@@ -11,7 +11,7 @@ build_vars:
   OUTPUT_IMAGE_NAME: '{{ app_name }}'
   OUTPUT_IMAGE_TAG: latest
   PUSH_SECRET: quay-registry-secret
-  BUILDER_IMAGE_NAME: registry.access.redhat.com/fuse7/fuse-java-openshift
+  BUILDER_IMAGE_NAME: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8
   BUILDER_IMAGE_TAG: 1.5
 
 pipeline_vars:

--- a/.applier/inventory/group_vars/all.yml
+++ b/.applier/inventory/group_vars/all.yml
@@ -11,8 +11,8 @@ build_vars:
   OUTPUT_IMAGE_NAME: '{{ app_name }}'
   OUTPUT_IMAGE_TAG: latest
   PUSH_SECRET: quay-registry-secret
-  BUILDER_IMAGE_NAME: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8
-  BUILDER_IMAGE_TAG: 1.5
+  BUILDER_IMAGE_NAME: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+  BUILDER_IMAGE_TAG: 1.8
 
 pipeline_vars:
   PIPELINE_SOURCE_REPOSITORY_URL: https://github.com/rht-labs/open-management-portal-git-api.git

--- a/README.md
+++ b/README.md
@@ -83,8 +83,13 @@ Create a secret file named `omp-cache-secret.yaml`. This secret will create an `
 
 ```
 apiVersion: v1
-data:
-  identities.yaml: Y3JlZGVudGlhbHM6Ci0gdXNlcm5hbWU6IG9tcAogIHBhc3N3b3JkOiBvbXAKLSB1c2VybmFtZTogb3BlcmF0b3IKICBwYXNzd29yZDogTDdFYXZOQklBRXhORDVHdAo=
+stringData:
+  identities.yaml: |+
+    credentials:
+    - username: omp
+      password: omp
+    - username: operator
+      password: operator1
 kind: Secret
 metadata:
   labels:

--- a/README.md
+++ b/README.md
@@ -7,11 +7,26 @@ If you want to learn more about Quarkus, please visit its website: https://quark
 
 Prior to running the app, you need to create a **Personal Access Token** linked to your GitLab account.
 
+### Local Infinispan (if necessary)
+
+Fire 🔥 up a docker instance of Infinispan to work with the app
+
+```
+docker run -it -p 11222:11222 -e USER="omp" -e PASS="omp" infinispan/server:10.1
+```
+
 ### Running in dev mode 
 
 You can run your application in dev mode that enables **live coding** using:
 ```
+export CACHE_CLIENT_INTELLIGENCE=<For mac dev set to BASIC>
+export CACHE_USE_AUTH=true
+export CONFIG_REPOSITORY_ID =<Git Repo id where the config files are>
+export GITLAB_API_URL=<The base url of your git api. ie https://gitlab.com>
 export GITLAB_PERSONAL_ACCESS_TOKEN=<GitLab Personal Access Token>
+export OMP_LOGGING=DEBUG
+export RESIDENCIES_PARENT_REPOSITORIES_ID=<Parent project id where repos will be saved>
+export TEMPLATE_REPOSITORY_ID=<Repo where template live>
 ./mvnw quarkus:dev
 ```
 
@@ -27,7 +42,14 @@ source ~/.zshrc
 
 You can run your application using Quarkus profiles using:
 ```
+export CACHE_CLIENT_INTELLIGENCE=<For mac dev set to BASIC>
+export CACHE_USE_AUTH=true
+export CONFIG_REPOSITORY_ID =<Git Repo id where the config files are>
+export GITLAB_API_URL=<The base url of your git api. ie https://gitlab.com>
 export GITLAB_PERSONAL_ACCESS_TOKEN=<GitLab Personal Access Token>
+export OMP_LOGGING=DEBUG
+export RESIDENCIES_PARENT_REPOSITORIES_ID=<Parent project id where repos will be saved>
+export TEMPLATE_REPOSITORY_ID=<Repo where template live>
 export QUARKUS_PROFILE=<Quarkus profile>
 ./mvnw clean package
 java -jar target/open-management-portal-git-api-*-runner.jar
@@ -51,20 +73,67 @@ You can then execute your binary: `./target/open-management-portal-git-api-1.0.0
 
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image-guide .
 
-## Add basic JDG to OCP
+## Add Infinispan to OCP via the Infinispan Operator
+
+* Cluster admin probably needed for CRD
+
+### Create secret
+
+Create a secret file named `omp-cache-secret.yaml`. This secret will create an `identities.yaml` file on the cache. Take note of the name that must match the app secret By default the user / pass will be omp / omp as defined in `src/main/resources/application.properties` and the secret below.
+
 ```
-oc new-app cache-service \
-    -p APPLICATION_USER=omp \
-    -p APPLICATION_PASSWORD=<PASSWORD> \
-    -p TOTAL_CONTAINER_MEM=4096 \
-    -p EVICTION_POLICY=reject \
-    -n <PROJECT_NAME>
+apiVersion: v1
+data:
+  identities.yaml: Y3JlZGVudGlhbHM6Ci0gdXNlcm5hbWU6IG9tcAogIHBhc3N3b3JkOiBvbXAKLSB1c2VybmFtZTogb3BlcmF0b3IKICBwYXNzd29yZDogTDdFYXZOQklBRXhORDVHdAo=
+kind: Secret
+metadata:
+  labels:
+    app: infinispan-secret-identities
+    clusterName: omp-cache
+    infinispan_cr: omp-cache
+  name: omp-cache-secret
+type: Opaque
+```
+
+### Create the Infinispan cluster file
+
+Create a file named infinispan-cluster.yaml
+
+```
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: omp-cache
+spec:
+  replicas: 1
+  image: infinispan/server:10.1
+  logging:
+    categories:
+      org.infinispan: info
+      org.jgroups: info
+  security:
+    endpointSecretName: omp-cache-secret
+```
+
+### Create the Infinispan Operator
+
+Login to OpenShift with the `oc` client and run the following commands
+
+```
+# Install Infinispan Operator running these commands
+oc apply -f omp-cache-secret.yaml
+oc apply -f https://raw.githubusercontent.com/infinispan/infinispan-operator/master/deploy/rbac.yaml
+oc apply -f https://raw.githubusercontent.com/infinispan/infinispan-operator/master/deploy/operator.yaml
+oc apply -f https://raw.githubusercontent.com/infinispan/infinispan-operator/master/deploy/crd.yaml
+
+# Create an Infinispan Cluster
+oc apply -f infinispan-cluster.yaml
 ```
 
 ## Configuration
 The preferred place to store non-sensitive data is in the application.properties.
 
-Sensitive fields like git repo location, repository id for residencies, repository id for the config and the GitLab API token are stored in the secrets.
+Sensitive fields like the gitlab token and cluster credentials should be stored in a OpenShift secret at a minimum. Other environment specific information should be stored in environmental variables such as repository id for residencies and repository id for the config.
 This info is stored in `ocp-s11/labs-test/omp-gitlab-configuration`.
 
 Deployment template will read from the above secret and inject following env variables. These are controlled from application.properties, so if a different env name is needed, change in the application properties file and the deployment template.
@@ -72,11 +141,16 @@ Deployment template will read from the above secret and inject following env var
 * `TEMPLATE_REPOSITORY_ID`
 * `RESIDENCIES_PARENT_REPOSITORIES_ID`
 * `GITLAB_API_URL`
-* `GITLAB_PERSONAL_ACCESS_TOKEN`
+* `GITLAB_PERSONAL_ACCESS_TOKEN` (should be secret and a service account)
+* `CACHE_SERVICE`
+* `CACHE_USER`
+* `CACHE_PASS` (should be secret and match the Infinispan operator secret)
+* `CACHE_USE_AUTH` set to true
+* *
 
 ### OpenShift Applier
 
-This project includes an `openshift-applier` inventory. To use it, make sure that you are logged in to the cluster and that you customize the variables in `.applier/inventory/group_vars/all.yml` - namely make sure that `deploy_vars` uses the correct endpoints. Once these are configured, you can deploy the project with:
+This section is not guaranteed to be up to date. This project includes an `openshift-applier` inventory. To use it, make sure that you are logged in to the cluster and that you customize the variables in `.applier/inventory/group_vars/all.yml` - namely make sure that `deploy_vars` uses the correct endpoints. Once these are configured, you can deploy the project with:
 
 ```bash
 cd .applier/
@@ -84,7 +158,7 @@ ansible-galaxy install -r requirements.yml --roles-path=roles --force
 ansible-playbook apply.yml -i inventory/
 ```
 
-## Pipeline
+## Pipeline (deprecated)
 
 The deployment pipeline is running through a `Jenkinsfile` located in the root folder of the project. This `Jenksinfile` is written in groovy.
 The pipeline expects the nexus is available nexus:8080. Make sure that nexus is available and accessible to Jenkins.

--- a/src/main/java/com/redhat/labs/cache/GitSyncManager.java
+++ b/src/main/java/com/redhat/labs/cache/GitSyncManager.java
@@ -23,6 +23,7 @@ import javax.inject.Singleton;
  *
  * @author faisalmasood
  */
+@Deprecated
 @Singleton
 public class GitSyncManager {
 

--- a/src/main/java/com/redhat/labs/cache/GitSyncService.java
+++ b/src/main/java/com/redhat/labs/cache/GitSyncService.java
@@ -1,0 +1,28 @@
+package com.redhat.labs.cache;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.redhat.labs.cache.cacheStore.ResidencyDataCache;
+import com.redhat.labs.omp.models.filesmanagement.SingleFileResponse;
+
+import io.quarkus.vertx.ConsumeEvent;
+
+@ApplicationScoped
+public class GitSyncService {
+    public static Logger LOGGER = LoggerFactory.getLogger(GitSyncService.class);
+    
+    public static final String FILE_CACHE_EVENT = "fileCacheEvent";
+    
+    @Inject
+    ResidencyDataCache cache;
+    
+    @ConsumeEvent(FILE_CACHE_EVENT)
+    public void consumeTemplate(SingleFileResponse message) {
+        LOGGER.warn("Caching repo file event::::  {} ", message.cacheKey);
+        cache.store(message);
+    }
+}

--- a/src/main/java/com/redhat/labs/cache/ResidencyDataStore.java
+++ b/src/main/java/com/redhat/labs/cache/ResidencyDataStore.java
@@ -22,7 +22,7 @@ public interface ResidencyDataStore {
      */
     public void store(String key, ResidencyInformation residencyInformation);
 
-    public void store(String key, SingleFileResponse file);
+    public void store(SingleFileResponse file);
 
     /**
      * return NULL if the key is not present
@@ -32,7 +32,7 @@ public interface ResidencyDataStore {
      * @param key
      * @return
      */
-    public ResidencyInformation fetch(String key);
+    public String fetch(String key);
 
     /**
      * return all the KEYS stored in the cahe.

--- a/src/main/java/com/redhat/labs/cache/cacheStore/ResidencyDataCache.java
+++ b/src/main/java/com/redhat/labs/cache/cacheStore/ResidencyDataCache.java
@@ -5,10 +5,13 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +20,7 @@ import com.redhat.labs.cache.ResidencyInformation;
 import com.redhat.labs.omp.models.filesmanagement.SingleFileResponse;
 
 import io.quarkus.infinispan.client.Remote;
+import io.quarkus.runtime.StartupEvent;
 
 /**
  * A very simple facade to write the cache data to remote JDG caches.
@@ -27,6 +31,13 @@ import io.quarkus.infinispan.client.Remote;
 public class ResidencyDataCache implements ResidencyDataStore {
 
     public static Logger LOGGER = LoggerFactory.getLogger(ResidencyDataCache.class);
+
+    void onStart(@Observes StartupEvent ev) {
+        LOGGER.debug("On start cache check available ==> {}", cache != null);
+        if(cache == null) {
+            createCache();
+        }
+    }
 
     @Inject
     protected RemoteCacheManager cacheManager;
@@ -44,8 +55,8 @@ public class ResidencyDataCache implements ResidencyDataStore {
     }
 
     @Override
-    public void store(String key, SingleFileResponse file) {
-    	cache.put(key,  file);
+    public void store(SingleFileResponse file) {
+        cache.put(file.cacheKey,  file.fileContent);
     }
 
     public void store(String key, String file) {
@@ -53,8 +64,8 @@ public class ResidencyDataCache implements ResidencyDataStore {
     }
 
     @Override
-    public ResidencyInformation fetch(String key) {
-        return (ResidencyInformation) cache.get(key);
+    public String fetch(String key) {
+        return (String) cache.get(key);
     }
 
     @Override
@@ -62,10 +73,15 @@ public class ResidencyDataCache implements ResidencyDataStore {
         return StreamSupport
                 .stream(cache.keySet().spliterator(), true)
                 .collect(Collectors.toList());
-
     }
     
     public void cleanCache() {
     	cache.clear();
+    }
+
+    private void createCache() {
+        LOGGER.info("Create OMP cache");
+        Configuration config = new ConfigurationBuilder().build();
+        cache = cacheManager.administration().createCache("omp", config);
     }
 }

--- a/src/main/java/com/redhat/labs/omp/models/filesmanagement/GetMultipleFilesResponse.java
+++ b/src/main/java/com/redhat/labs/omp/models/filesmanagement/GetMultipleFilesResponse.java
@@ -9,4 +9,8 @@ import java.util.List;
 public class GetMultipleFilesResponse implements Serializable {
     @JsonbProperty("files")
     public List<SingleFileResponse> files;
+
+    public String toString() {
+        return GetMultipleFilesResponse.class.getName() + " :: " + files;
+    }
 }

--- a/src/main/java/com/redhat/labs/omp/models/filesmanagement/SingleFileResponse.java
+++ b/src/main/java/com/redhat/labs/omp/models/filesmanagement/SingleFileResponse.java
@@ -1,13 +1,12 @@
 package com.redhat.labs.omp.models.filesmanagement;
 
 import javax.json.bind.annotation.JsonbProperty;
-import java.io.Serializable;
 
 /**
  * This class defines the single file content fetchged from Git.
  *
  */
-public class SingleFileResponse implements Serializable {
+public class SingleFileResponse {
 
     public SingleFileResponse(){
 
@@ -15,7 +14,6 @@ public class SingleFileResponse implements Serializable {
 
     public SingleFileResponse(String fileName, String fileContent){
         this.fileName = fileName;
-
         this.fileContent = fileContent;
     }
 
@@ -25,7 +23,17 @@ public class SingleFileResponse implements Serializable {
     @JsonbProperty("fileContent")
     public  String fileContent;
 
+    public String cacheKey;
+
+    public void setCacheKey(String repoId, String branch) {
+        cacheKey = String.format("%s:%s:%s", fileName, repoId, branch);
+    }
+
     public String getFileContent(){
         return fileContent;
+    }
+
+    public String toString() {
+        return String.format("Single FileResponse: name: %s contents: %s", fileName, fileContent);
     }
 }

--- a/src/main/java/com/redhat/labs/omp/resources/CacheResource.java
+++ b/src/main/java/com/redhat/labs/omp/resources/CacheResource.java
@@ -84,7 +84,7 @@ public class CacheResource {
         GetFileResponse metaFileResponse = gitLabService.getFile(templateRepositoryId, fileName, "master");
         String base64Content = metaFileResponse.content;
         String content = new String(Base64.getDecoder().decode(base64Content), StandardCharsets.UTF_8);
-        LOGGER.info("File {} content fetched {}", fileName, content);
+        LOGGER.debug("File {} content fetched {}", fileName, content);
         return new SingleFileResponse(fileName, content);
     }
 }

--- a/src/main/java/com/redhat/labs/omp/resources/FileResource.java
+++ b/src/main/java/com/redhat/labs/omp/resources/FileResource.java
@@ -1,10 +1,13 @@
 package com.redhat.labs.omp.resources;
 
+import com.redhat.labs.cache.GitSyncService;
 import com.redhat.labs.cache.cacheStore.ResidencyDataCache;
 import com.redhat.labs.omp.models.GetFileResponse;
 import com.redhat.labs.omp.models.filesmanagement.SingleFileResponse;
 import com.redhat.labs.omp.resources.filters.Logged;
 import com.redhat.labs.omp.services.GitLabService;
+
+import io.vertx.axle.core.eventbus.EventBus;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -29,6 +32,9 @@ public class FileResource {
     protected GitLabService gitLabService;
     
     @Inject
+    protected EventBus bus;
+
+    @Inject
     protected ResidencyDataCache cache;
 
     @ConfigProperty(name = "file_branch", defaultValue = "master")
@@ -45,15 +51,24 @@ public class FileResource {
             LOGGER.debug(String.format("Template Repo %s filename %s branch %s", templateRepositoryId, fileName, branch));
         }
 
+        String key = String.format("%s:%s:%s", fileName, templateRepositoryId, branch == null ? defaultBranch : branch);
+
+        String fileContent = cache.fetch(key);
+        if(fileContent != null) {
+            LOGGER.debug("Cache hit for key {}", key);
+            return new SingleFileResponse(fileName, fileContent);
+        }
+
+        LOGGER.info("Cache miss for key: {}", key);
         GetFileResponse metaFileResponse = gitLabService.getFile(templateRepositoryId, fileName, branch == null ? defaultBranch : branch);
         String base64Content = metaFileResponse.content;
         String content = new String(Base64.getDecoder().decode(base64Content), StandardCharsets.UTF_8);
         LOGGER.debug("File {} content fetched {}", fileName, content);
         SingleFileResponse response = new SingleFileResponse(fileName, content);
         if(content != null) {
-            String cacheJson = JsonbBuilder.create().toJson(response);
             LOGGER.info("adding {} to cache", fileName);
-            cache.store(fileName, cacheJson);
+            response.cacheKey = key;
+            bus.publish(GitSyncService.FILE_CACHE_EVENT, response);
         }
         return response;
     }

--- a/src/main/java/com/redhat/labs/omp/resources/TemplateResource.java
+++ b/src/main/java/com/redhat/labs/omp/resources/TemplateResource.java
@@ -1,11 +1,14 @@
 package com.redhat.labs.omp.resources;
 
-
+import com.redhat.labs.cache.GitSyncService;
 import com.redhat.labs.omp.models.filesmanagement.CommitMultipleFilesInRepsitoryRequest;
 import com.redhat.labs.omp.models.filesmanagement.GetMultipleFilesResponse;
 import com.redhat.labs.omp.models.filesmanagement.SingleFileResponse;
 import com.redhat.labs.omp.resources.filters.Logged;
 import com.redhat.labs.omp.services.GitLabService;
+
+import io.vertx.axle.core.eventbus.EventBus;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
@@ -39,6 +42,9 @@ public class TemplateResource {
     @Inject
     protected FileResource fileResource;
 
+    @Inject
+    protected EventBus bus;
+
     /**
      * This method returns a map which contains filename to filecontent rows
      *
@@ -50,7 +56,10 @@ public class TemplateResource {
 
         List<SingleFileResponse> allFiles = new ArrayList<>(10);
 
+        //TODO cache this
         SingleFileResponse metaFileContent = fileResource.fetchContentFromGit(metaFileFolder + "/meta.dat", templateRepositoryId);
+
+        bus.publish(GitSyncService.FILE_CACHE_EVENT, metaFileContent);
 
         String[] lines = metaFileContent.getFileContent().split("\\r?\\n");
         for (String line : lines) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,9 +4,10 @@ gitlab.api/mp-rest/scope=javax.inject.Singleton
 # Quarkus logging properties
 quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
-quarkus.log.console.level=INFO
+quarkus.log.console.level=DEBUG
 quarkus.log.console.color=false
-quarkus.log.category."io.quarkus".level=DEBUG
+quarkus.log.category."io.quarkus".level=INFO
+quarkus.log.category."com.redhat.labs".level=${OMP_LOGGING:INFO}
 %dev.quarkus.log.console.json=false
 %test.quarkus.log.console.json=false
 
@@ -20,7 +21,7 @@ quarkus.infinispan-client.auth-password=${CACHE_PASS:omp}
 quarkus.infinispan-client.use-auth=${CACHE_USE_AUTH:false}
 quarkus.infinispan-client.auth-server-name=${CACHE_AUTH_SERVER:infinispan}
 quarkus.infinispan-client.auth-realm=${CACHE_REALM:default}
-#quarkus.infinispan-client.client-intelligence=BASIC
+quarkus.infinispan-client.client-intelligence=${CACHE_CLIENT_INTELLIGENCE:HASH_DISTRIBUTION_AWARE}
 
 # Quarkus HTTP properties
 quarkus.http.cors=true


### PR DESCRIPTION
* Initial Cache implementation. Uses vertx event bus to publish events that then stores the data in cache. This caches raw file data keyed by filename:repo_id:branch
See FileResource for publishing event and GitSyncService for consuming the event
* Updates the Readme - helpful for local dev and env vars needed for deployment. The dc is not updated here. There is an open issue around updating the dc.
* Updating logging config so that it's easier to set the log level to debug when developing