### PR TITLE
File API Encoded Wrong Value

### DIFF
--- a/src/main/java/com/redhat/labs/omp/models/gitlab/File.java
+++ b/src/main/java/com/redhat/labs/omp/models/gitlab/File.java
@@ -62,7 +62,7 @@ public class File {
 
         // encode contents
         if (null != content) {
-            byte[] encodedContents = EncodingUtils.base64Encode(this.filePath.getBytes());
+            byte[] encodedContents = EncodingUtils.base64Encode(this.content.getBytes());
             this.content = new String(encodedContents, StandardCharsets.UTF_8);
         }
 


### PR DESCRIPTION
This is a bug fix.

When the file was encoded before calling the Gitlab API, it was using the filePath attribute instead of the content so when the file was created, the contents were incorrect.