### PR TITLE
Add ghost build for non-code changes

### DIFF
--- a/.github/workflows/pull-request-checks-disabled.yml
+++ b/.github/workflows/pull-request-checks-disabled.yml
@@ -1,4 +1,4 @@
-name: PR check
+name: PR check without code changes
 
 on:
   pull_request:
@@ -6,6 +6,8 @@ on:
       - deployment/**
       - development/**
       - .vscode/**
+      - !src/**
+      - !s2i/**
 
 jobs:
   build:

--- a/.github/workflows/pull-request-checks-disabled.yml
+++ b/.github/workflows/pull-request-checks-disabled.yml
@@ -6,8 +6,8 @@ on:
       - deployment/**
       - development/**
       - .vscode/**
-      - !src/**
-      - !s2i/**
+      - "!src/**"
+      - "!s2i/**"
 
 jobs:
   build:

--- a/.github/workflows/pull-request-checks-disabled.yml
+++ b/.github/workflows/pull-request-checks-disabled.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Skip build
-      run: echo "This build has been skipped."
+      run: echo "This build has been skipped because the only changes are in non-code directories."

--- a/.github/workflows/pull-request-checks-disabled.yml
+++ b/.github/workflows/pull-request-checks-disabled.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - "!**"
       - deployment/**
-      - development/**
       - .vscode/**
 
 jobs:

--- a/.github/workflows/pull-request-checks-disabled.yml
+++ b/.github/workflows/pull-request-checks-disabled.yml
@@ -1,0 +1,15 @@
+name: PR check
+
+on:
+  pull_request:
+    paths:
+      - deployment/**
+      - development/**
+      - .vscode/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Skip build
+      run: echo "This build has been skipped."

--- a/.github/workflows/pull-request-checks-disabled.yml
+++ b/.github/workflows/pull-request-checks-disabled.yml
@@ -6,6 +6,9 @@ on:
       - "!**"
       - deployment/**
       - .vscode/**
+      - README.md
+      - lombok.config
+      - .gitignore
 
 jobs:
   build:

--- a/.github/workflows/pull-request-checks-disabled.yml
+++ b/.github/workflows/pull-request-checks-disabled.yml
@@ -3,11 +3,10 @@ name: PR check without code changes
 on:
   pull_request:
     paths:
+      - "!**"
       - deployment/**
       - development/**
       - .vscode/**
-      - "!src/**"
-      - "!s2i/**"
 
 jobs:
   build:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - deployment/**
-      - development/**
       - .vscode/**
 
 jobs:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - deployment/**
       - .vscode/**
+      - README.md
+      - lombok.config
+      - .gitignore
 
 jobs:
   build:


### PR DESCRIPTION
@mcanoy's idea worked - a dummy job with the same name (`build`) but logically opposite path triggering seems to also satisfy the branch protection requirements