### PR TITLE
Bugfix: Group Creation Not Saving to Correct Project

### DIFF
--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -140,7 +140,7 @@ public class EngagementService {
 
     private Group getOrCreateGroup(String groupName, Group groupToCreate) {
 
-        Optional<Group> optional = groupService.getGitLabGroupByName(groupName);
+        Optional<Group> optional = groupService.getGitLabGroupByName(groupName, groupToCreate.getParentId());
 
         if (!optional.isPresent()) {
 

--- a/src/main/java/com/redhat/labs/omp/service/GroupService.java
+++ b/src/main/java/com/redhat/labs/omp/service/GroupService.java
@@ -24,7 +24,8 @@ public class GroupService {
     GitLabService gitLabService;
 
     // get a group
-    public Optional<Group> getGitLabGroupByName(String name) throws UnexpectedGitLabResponseException {
+    public Optional<Group> getGitLabGroupByName(String name, Integer parentId)
+            throws UnexpectedGitLabResponseException {
 
         Optional<Group> optional = Optional.empty();
 
@@ -35,8 +36,8 @@ public class GroupService {
         }
 
         // look for a match between returned name and provided path
-        for(Group group : groupList) {
-            if(name.equals(group.getPath())) {
+        for (Group group : groupList) {
+            if (name.equals(group.getPath()) && parentId.equals(group.getParentId())) {
                 return Optional.of(group);
             }
         }
@@ -45,15 +46,16 @@ public class GroupService {
 
     }
 
-    public  List<Group> getAllGroups(Integer engagementRepositoryId) {
+    public List<Group> getAllGroups(Integer engagementRepositoryId) {
 
-        //FIRST LEVEL
+        // FIRST LEVEL
         List<Group> customerGroups = gitLabService.getSubGroups(engagementRepositoryId);
 
         List<Group> customerEngagementGroups = new ArrayList<>();
-        customerGroups.stream().forEach(group -> customerEngagementGroups.addAll(gitLabService.getSubGroups(group.getId())));
+        customerGroups.stream()
+                .forEach(group -> customerEngagementGroups.addAll(gitLabService.getSubGroups(group.getId())));
 
-        if(LOGGER.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             customerEngagementGroups.stream().forEach(group -> LOGGER.debug("Group -> {}", group.getName()));
         }
 

--- a/src/main/java/com/redhat/labs/omp/service/GroupService.java
+++ b/src/main/java/com/redhat/labs/omp/service/GroupService.java
@@ -34,20 +34,14 @@ public class GroupService {
             return optional;
         }
 
-        if (1 == groupList.size()) {
-            return Optional.of(groupList.get(0));
-        }
-
-        // found more than one group with name in either 'name' or 'path' attribute
-        // should match path
+        // look for a match between returned name and provided path
         for(Group group : groupList) {
-            if(name.equalsIgnoreCase(group.getPath())) {
+            if(name.equals(group.getPath())) {
                 return Optional.of(group);
             }
         }
 
-        throw new UnexpectedGitLabResponseException(
-                "No resource found with name equal to path attribute.");
+        return optional;
 
     }
 

--- a/src/main/java/com/redhat/labs/omp/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/omp/service/ProjectService.java
@@ -35,14 +35,9 @@ public class ProjectService {
             return optional;
         }
 
-        if (1 == resultList.size()) {
-            return Optional.of(Project.from(resultList.get(0)));
-        }
-
-        // found more than one project with name in either 'name' or 'path' attribute
-        // should match path
+        // look for a project with name that matches the namespace id and the path
         for (ProjectSearchResults result : resultList) {
-            if (namespaceId.equals(result.getNamespace().getId()) && name.equalsIgnoreCase(result.getPath())) {
+            if (namespaceId.equals(result.getNamespace().getId()) && name.equals(result.getPath())) {
                 return Optional.of(Project.from(result));
             }
         }

--- a/src/test/java/com/redhat/labs/omp/mocks/MockGitLabService.java
+++ b/src/test/java/com/redhat/labs/omp/mocks/MockGitLabService.java
@@ -61,6 +61,9 @@ public class MockGitLabService implements GitLabService {
             groupList.add(Group.builder().id(3).name("customer1").path("customer1").build());
         } else if ("project4".equalsIgnoreCase(name)) {
             groupList.add(Group.builder().id(4).name("project1").path("project1").build());
+        } else if ("customer".equalsIgnoreCase(name)) {
+            groupList.add(Group.builder().id(11).name("customerA").path("customerA").parentId(10).build());
+            groupList.add(Group.builder().id(12).name("customer").path("customer").parentId(10).build());
         }
 
         return groupList;

--- a/src/test/java/com/redhat/labs/omp/service/GroupServiceTest.java
+++ b/src/test/java/com/redhat/labs/omp/service/GroupServiceTest.java
@@ -1,0 +1,44 @@
+package com.redhat.labs.omp.service;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.labs.omp.models.gitlab.Group;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class GroupServiceTest {
+
+    @Inject
+    GroupService groupService;
+    
+    @Test
+    public void testGetGitLabGroupByNameNoGroupsExist() {
+
+        Optional<Group> optional = groupService.getGitLabGroupByName("customerA", 1);
+        Assertions.assertFalse(optional.isPresent());
+
+    }
+
+    @Test
+    public void testGetGitLabGroupByNameMultipleGroupsExistNoMatch() {
+
+        Optional<Group> optional = groupService.getGitLabGroupByName("customer", 1);
+        Assertions.assertFalse(optional.isPresent());
+
+    }
+
+    @Test
+    public void testGetGitLabGroupByNameMultipleGroupsExistMatch() {
+
+        Optional<Group> optional = groupService.getGitLabGroupByName("customer", 10);
+        Assertions.assertTrue(optional.isPresent());
+
+    }
+
+}


### PR DESCRIPTION
- GroupService.getGitLabGroupByName now checks both exact name and parent id to validate if a group already exists
- ProjectService.getProjectByName now checks exact name and parent/namespace id to validate if a project already exists