### PR TITLE
Use Get All Projects By Group for Engagements

### DIFF
--- a/src/main/java/com/redhat/labs/omp/rest/client/GitLabService.java
+++ b/src/main/java/com/redhat/labs/omp/rest/client/GitLabService.java
@@ -34,7 +34,7 @@ public interface GitLabService {
     // reference: https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects
     @GET
     @Path("/groups/{id}/projects")
-    List<Project> getProjectsbyGroup(@PathParam("id") @Encoded Integer groupId);
+    List<Project> getProjectsbyGroup(@PathParam("id") @Encoded Integer groupId, @QueryParam("include_subgroups") @Encoded Boolean includeSubgroups);
 
     //reference: https://docs.gitlab.com/ee/api/groups.html#list-a-groups-subgroups
     @GET

--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -94,7 +94,6 @@ public class EngagementService {
      */
     public List<Engagement> getAllEngagements() {
 
-//        List<ProjectSearchResults> projects = projectService.getAllProjectsByNane("iac");
         List<Project> projects = projectService.getProjectsByGroup(engagementRepositoryId, true);
 
         List<Engagement> engagementFiles = new ArrayList<>();

--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -94,11 +94,12 @@ public class EngagementService {
      */
     public List<Engagement> getAllEngagements() {
 
-        List<ProjectSearchResults> projects = projectService.getAllProjectsByNane("iac");
+//        List<ProjectSearchResults> projects = projectService.getAllProjectsByNane("iac");
+        List<Project> projects = projectService.getProjectsByGroup(engagementRepositoryId, true);
 
         List<Engagement> engagementFiles = new ArrayList<>();
 
-        for (ProjectSearchResults project : projects) {
+        for (Project project : projects) {
             LOGGER.debug("project id {}", project.getId());
             Optional<File> engagementFile = fileService.getFileAllow404(project.getId(), "engagement.json");
             if (engagementFile.isPresent()) {

--- a/src/main/java/com/redhat/labs/omp/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/omp/service/ProjectService.java
@@ -50,8 +50,8 @@ public class ProjectService {
         return gitLabService.getProjectByName(name);
     }
 
-    public List<Project> getProjects(int groupId) {
-        List<Project> projects = gitLabService.getProjectsbyGroup(groupId);
+    public List<Project> getProjectsByGroup(int groupId, Boolean includeSubgroups) {
+        List<Project> projects = gitLabService.getProjectsbyGroup(groupId, includeSubgroups);
 
         if(LOGGER.isDebugEnabled()) {
             LOGGER.trace("project count group id({}) {}", groupId, projects.size());

--- a/src/test/java/com/redhat/labs/omp/mocks/MockGitLabService.java
+++ b/src/test/java/com/redhat/labs/omp/mocks/MockGitLabService.java
@@ -212,7 +212,7 @@ public class MockGitLabService implements GitLabService {
     }
 
     @Override
-    public List<Project> getProjectsbyGroup(Integer groupId) {
+    public List<Project> getProjectsbyGroup(Integer groupId, Boolean includeSubgroups) {
         List<Project> projects = new ArrayList<>();
         projects.add(Project.builder().id(groupId * 10).name("Project " + (groupId*10)).build());
         return projects;

--- a/src/test/java/com/redhat/labs/omp/service/ProjectServiceTest.java
+++ b/src/test/java/com/redhat/labs/omp/service/ProjectServiceTest.java
@@ -38,7 +38,7 @@ public class ProjectServiceTest {
     
     @Test 
     public void getProjectsByGroup() {
-        List<Project> projects = projectService.getProjects(10);
+        List<Project> projects = projectService.getProjectsByGroup(10, true);
         
         Assertions.assertEquals(1, projects.size());
     }


### PR DESCRIPTION
- using the GitLab API to get all projects by group instead of searching for projects by name