### PR TITLE
Get Group By Name Should Validate Against GitLab Group Name

### DIFF
--- a/src/main/java/com/redhat/labs/omp/service/EngagementService.java
+++ b/src/main/java/com/redhat/labs/omp/service/EngagementService.java
@@ -21,7 +21,6 @@ import com.redhat.labs.omp.models.gitlab.File;
 import com.redhat.labs.omp.models.gitlab.FileAction;
 import com.redhat.labs.omp.models.gitlab.Group;
 import com.redhat.labs.omp.models.gitlab.Project;
-import com.redhat.labs.omp.models.gitlab.ProjectSearchResults;
 import com.redhat.labs.omp.utils.GitLabPathUtils;
 
 @ApplicationScoped

--- a/src/main/java/com/redhat/labs/omp/service/GroupService.java
+++ b/src/main/java/com/redhat/labs/omp/service/GroupService.java
@@ -37,7 +37,7 @@ public class GroupService {
 
         // look for a match between returned name and provided path
         for (Group group : groupList) {
-            if (name.equals(group.getPath()) && parentId.equals(group.getParentId())) {
+            if (name.equals(group.getName()) && parentId.equals(group.getParentId())) {
                 return Optional.of(group);
             }
         }

--- a/src/test/java/com/redhat/labs/omp/mocks/MockGitLabService.java
+++ b/src/test/java/com/redhat/labs/omp/mocks/MockGitLabService.java
@@ -59,10 +59,10 @@ public class MockGitLabService implements GitLabService {
 
         if ("customer3".equalsIgnoreCase(name)) {
             groupList.add(Group.builder().id(3).name("customer1").path("customer1").build());
-        } else if ("project4".equalsIgnoreCase(name)) {
-            groupList.add(Group.builder().id(4).name("project1").path("project1").build());
-        } else if ("customer".equalsIgnoreCase(name)) {
-            groupList.add(Group.builder().id(11).name("customerA").path("customerA").parentId(10).build());
+        } else if ("project1".equalsIgnoreCase(name)) {
+            groupList.add(Group.builder().id(4).name("project1").path("project1").parentId(11).build());
+        } else if ("customer".equalsIgnoreCase(name) || "customer A".equalsIgnoreCase(name)) {
+            groupList.add(Group.builder().id(11).name("customer A").path("customer-a").parentId(2).build());
             groupList.add(Group.builder().id(12).name("customer").path("customer").parentId(10).build());
         }
 

--- a/src/test/java/com/redhat/labs/omp/resource/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resource/EngagementResourceTest.java
@@ -43,5 +43,18 @@ public class EngagementResourceTest {
             .then()
                 .statusCode(201);
     }
-    
+
+    @Test
+    public void testUpdateEngagementSuccess() {
+        given()
+            .when()
+                .contentType(ContentType.JSON)
+                .queryParam("username", "jdoe")
+                .queryParam("userEmail", "jdoe@email.com")
+                .body(ResourceLoader.load("engagement-update.json"))
+                .post("/api/v1/engagements")
+            .then()
+                .statusCode(201);
+    }
+
 }

--- a/src/test/resources/engagement-update.json
+++ b/src/test/resources/engagement-update.json
@@ -1,0 +1,22 @@
+{
+    "archive_date": "20210125",
+    "customer_contact_email": "reg@chiefs.com",
+    "customer_contact_name": "Reg Dunlop",
+    "customer_name": "customer A",
+    "description": "Charleston",
+    "end_date": "20201225",
+    "engagement_lead_email": "doug93@leafs.com",
+    "engagement_lead_name": "Doug Gilmour",
+    "project_id": 0,
+    "location": "Raleigh, NC",
+    "ocp_cloud_provider_name": "GCP",
+    "ocp_cloud_provider_region": "West",
+    "ocp_cluster_size": "medium",
+    "ocp_persistent_storage_size": "50GB",
+    "ocp_sub_domain": "jello",
+    "ocp_version": "v4.2",
+    "project_name": "project1",
+    "start_date": "20200202",
+    "technical_lead_email": "wendel17@leafs.com",
+    "technical_lead_name": "Wendel Clark"
+}


### PR DESCRIPTION
- the GroupService.getGitLabGroupByName was checking that the provided group (customer or project) name matched the path.  It should have been the group name as the path is now being modified to conform to GitLab standards.
- added test case for update scenario