### PR TITLE
Add ability to preserve gitlab projects with DO_NOT_DELETE tag

### DIFF
--- a/src/main/java/com/redhat/labs/omp/models/gitlab/Project.java
+++ b/src/main/java/com/redhat/labs/omp/models/gitlab/Project.java
@@ -1,5 +1,6 @@
 package com.redhat.labs.omp.models.gitlab;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -17,6 +18,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Project {
+
+    private static final String DO_NOT_DELETE = "DO_NOT_DELETE";
 
     @JsonbProperty("id")
     private Integer id;
@@ -141,6 +144,16 @@ public class Project {
                 .namespaceId(result.getNamespace().getId()).build();
         return p;
 
+    }
+
+    public void preserve() {
+        if(tagList == null) {
+            tagList = new ArrayList<String>();
+        }
+
+        if(!tagList.contains(DO_NOT_DELETE)) {
+            tagList.add(DO_NOT_DELETE);
+        }
     }
 
 }

--- a/src/main/java/com/redhat/labs/omp/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/omp/service/ProjectService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +23,9 @@ public class ProjectService {
     @Inject
     @RestClient
     GitLabService gitLabService;
+
+    @ConfigProperty(name = "engagements.do.not.delete")
+    boolean doNotDelete;
 
     // get a project
     public Optional<Project> getProjectByName(Integer namespaceId, String name)
@@ -53,7 +57,7 @@ public class ProjectService {
     public List<Project> getProjectsByGroup(int groupId, Boolean includeSubgroups) {
         List<Project> projects = gitLabService.getProjectsbyGroup(groupId, includeSubgroups);
 
-        if(LOGGER.isDebugEnabled()) {
+        if(LOGGER.isTraceEnabled()) {
             LOGGER.trace("project count group id({}) {}", groupId, projects.size());
             projects.stream().forEach(project -> LOGGER.debug("Group {} Project {}", groupId, project.getName()));
         }
@@ -79,6 +83,12 @@ public class ProjectService {
     public Optional<Project> createProject(Project project) {
 
         Optional<Project> optional = Optional.empty();
+
+        if(doNotDelete) {
+            project.preserve();
+        }
+
+        LOGGER.debug("create project  " + project);
 
         // try to create project
         Project createdProject = gitLabService.createProject(project);

--- a/src/main/java/com/redhat/labs/omp/service/ProjectService.java
+++ b/src/main/java/com/redhat/labs/omp/service/ProjectService.java
@@ -57,7 +57,7 @@ public class ProjectService {
     public List<Project> getProjectsByGroup(int groupId, Boolean includeSubgroups) {
         List<Project> projects = gitLabService.getProjectsbyGroup(groupId, includeSubgroups);
 
-        if(LOGGER.isTraceEnabled()) {
+        if(LOGGER.isDebugEnabled()) {
             LOGGER.trace("project count group id({}) {}", groupId, projects.size());
             projects.stream().forEach(project -> LOGGER.debug("Group {} Project {}", groupId, project.getName()));
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,7 @@ config.file=${CONFIG_FILE:schema/config.yml}
 
 # engagements
 engagements.repository.id=${ENGAGEMENTS_REPOSITORY_ID:2}
+engagements.do.not.delete=${ENGAGEMENTS_PRESERVE:false}
 
 # version
 git.commit=${GIT_API_GIT_COMMIT:not.set}


### PR DESCRIPTION
by adding this tag  a cronjob can look in the projects `tag_list` and see if there is one marked DO_NOT_DELETE. The cronjob should respect this tag. (tag_list is not a git tag). This is off by default. 